### PR TITLE
github: bump GH action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install texlive
       run: |
         sudo apt-get install texlive-latex-extra texlive-fonts-extra


### PR DESCRIPTION
Node 20 is deprecated. Bump GitHub action dependencies to versions that run on more recent node.